### PR TITLE
Fix: Player Jump Force

### DIFF
--- a/Assets/Resources/ModularFirstPersonController/FirstPersonController/FirstPersonController.cs
+++ b/Assets/Resources/ModularFirstPersonController/FirstPersonController/FirstPersonController.cs
@@ -466,7 +466,8 @@ public class FirstPersonController : MonoBehaviour
         // Adds force to the player rigidbody to jump
         if (isGrounded)
         {
-            rb.AddForce(0f, jumpPower, 0f, ForceMode.Impulse);
+            Vector3 normalVec = rb.velocity.normalized;
+            rb.AddForce(0f, jumpPower * (1 - normalVec.y), 0f, ForceMode.Impulse);
             isGrounded = false;
         }
 


### PR DESCRIPTION
제목 : feat: 기능명

## 🖥️Part
Programmer

## 📝작업 내용

계단에서 점프할 때 슈퍼 점프가 되는 문제 해결

### 원인
계단을 올라가는 도중에는 위로 향하는 힘이 0이 아닌 상태가 됩니다. 이 상태에서 AddForce를 호출하면 점프하는 힘이 지면에서 보다 강해지는 문제가 발생하는 것 입니다.

### 해결
Rigidbody의 velocity vector의 노멀 vector를 구하고, y값을 빼서 올라가는 도중 점프할 경우 힘을 조절함.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
