### PR TITLE
Fix: 계단 오브젝트 롤백

### DIFF
--- a/Assets/Prefabs/Map/BaseMap.prefab
+++ b/Assets/Prefabs/Map/BaseMap.prefab
@@ -911,10 +911,7 @@ PrefabInstance:
       value: 6
       objectReference: {fileID: 0}
     m_RemovedComponents: []
-    m_RemovedGameObjects:
-    - {fileID: -7262274070808441943, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
-    - {fileID: -7209469120377829973, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
-    - {fileID: -4261974198495748979, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
+    m_RemovedGameObjects: []
     m_AddedGameObjects: []
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 1092179050124001086, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a,

--- a/Assets/Prefabs/Map/DefaultMaps/DefaultMap.prefab
+++ b/Assets/Prefabs/Map/DefaultMaps/DefaultMap.prefab
@@ -10066,18 +10066,6 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 373582435615469294}
-    - targetCorrespondingSourceObject: {fileID: 6269952331931581899, guid: d8aa47eb051537e4db8936f462df99ac,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 276261521564371926}
-    - targetCorrespondingSourceObject: {fileID: 6324938787117626313, guid: d8aa47eb051537e4db8936f462df99ac,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1729831202913926991}
-    - targetCorrespondingSourceObject: {fileID: 588818616390345965, guid: d8aa47eb051537e4db8936f462df99ac,
-        type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 4664692806032034938}
     - targetCorrespondingSourceObject: {fileID: 8422603149860510417, guid: d8aa47eb051537e4db8936f462df99ac,
         type: 3}
       insertIndex: -1
@@ -10257,34 +10245,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   animator: {fileID: 0}
---- !u!1 &1820147891363896268 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 588818616390345965, guid: d8aa47eb051537e4db8936f462df99ac,
-    type: 3}
-  m_PrefabInstance: {fileID: 1254694175165562657}
-  m_PrefabAsset: {fileID: 0}
---- !u!64 &4664692806032034938
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1820147891363896268}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: 8426613718395732177, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
 --- !u!1 &2097787964072115578 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 897701480589754971, guid: d8aa47eb051537e4db8936f462df99ac,
@@ -10749,62 +10709,6 @@ MeshCollider:
   m_Convex: 0
   m_CookingOptions: 30
   m_Mesh: {fileID: 2999365791171920825, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
---- !u!1 &5074089866096493290 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6269952331931581899, guid: d8aa47eb051537e4db8936f462df99ac,
-    type: 3}
-  m_PrefabInstance: {fileID: 1254694175165562657}
-  m_PrefabAsset: {fileID: 0}
---- !u!64 &276261521564371926
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5074089866096493290}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -6592000232013268071, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
---- !u!1 &5093329167957806312 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 6324938787117626313, guid: d8aa47eb051537e4db8936f462df99ac,
-    type: 3}
-  m_PrefabInstance: {fileID: 1254694175165562657}
-  m_PrefabAsset: {fileID: 0}
---- !u!64 &1729831202913926991
-MeshCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5093329167957806312}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 5
-  m_Convex: 1
-  m_CookingOptions: 30
-  m_Mesh: {fileID: -8191522601684616745, guid: 81dca0c9ab4e0ce45b8fb34bfbffa46a, type: 3}
 --- !u!1 &5178409518218023063 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 6247893123261640630, guid: d8aa47eb051537e4db8936f462df99ac,

--- a/Assets/Scenes/Dev/LJH/LDTest.unity
+++ b/Assets/Scenes/Dev/LJH/LDTest.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028326, g: 0.22571333, b: 0.30692202, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -404,6 +404,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: DefaultMap_2Ch
       objectReference: {fileID: 0}
+    - target: {fileID: 8241887383551660762, guid: 1a229441cffa447be8682b47acf55f14,
+        type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -759,7 +764,7 @@ PrefabInstance:
     - target: {fileID: 8241887383551660762, guid: 99f8fe26392c4a64ba4ff2c08db496ae,
         type: 3}
       propertyPath: m_IsActive
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8908765555635349734, guid: 99f8fe26392c4a64ba4ff2c08db496ae,
         type: 3}


### PR DESCRIPTION
## 🖥️Part
기획

## 📝작업 내용

> 계단 오브젝트 롤백
- 사라졌던 계단 오브젝트를 다시 활성화 시켰습니다.
- 원인은 BaseMap의 mapV4의 계단 오브젝트가 삭제되었고, mapV4.prefab과의 변동 사항에서 revert해서 다시 롤백 시켰습니다.

### 스크린샷 (선택)
<img width="1440" alt="스크린샷 2024-11-09 오후 2 10 04" src="https://github.com/user-attachments/assets/915b4fac-8867-4899-a0d9-51fe8f34b16d">

## 💬리뷰 요구사항(선택)
> 계단 오브젝트 확인
- Dev/LJH/LDTest 씬에 계단이 정상적으로 있는지 확인해주세요
