### PR TITLE
Feat: 설정 UI 커서 모드 수정 및 민감도 정보 전달 

### DIFF
--- a/Assets/Prefabs/UI/SettingUIManager.prefab
+++ b/Assets/Prefabs/UI/SettingUIManager.prefab
@@ -1076,10 +1076,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 6536997525075492302}
   m_HandleRect: {fileID: 6179053010454761198}
   m_Direction: 0
-  m_MinValue: 0
-  m_MaxValue: 1
+  m_MinValue: 50
+  m_MaxValue: 150
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 100
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -1799,12 +1799,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 03c9bef4c4cc7f649a1c6cfb16a9c083, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  Persistent: 0
+  Persistent: 1
   settingUICanvas: {fileID: 4056395085840594347}
   settingKeyCode: 27
   bgmSlider: {fileID: 3141708962275313512}
   sfxSlider: {fileID: 6389146681553165285}
+  onSensitivityValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
   mouseSlider: {fileID: 6000724965002142181}
+  curSensitivity: 0
+  minSensitivity: 50
+  maxSensitivity: 150
   continueBtn: {fileID: 1738964026820454514}
   exitBtn: {fileID: 2923909786683945060}
 --- !u!1 &5271372200208410208

--- a/Assets/Scenes/Dev/LJH/LDTest_4Ch.unity
+++ b/Assets/Scenes/Dev/LJH/LDTest_4Ch.unity
@@ -309,6 +309,74 @@ MonoBehaviour:
   m_LightCookieSize: {x: 1, y: 1}
   m_LightCookieOffset: {x: 0, y: 0}
   m_SoftShadowQuality: 0
+--- !u!1001 &267538456
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362152, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2223489818624362158, guid: 087d093decbf92046ba7c03955196eb9,
+        type: 3}
+      propertyPath: m_Name
+      value: SoundManager
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 087d093decbf92046ba7c03955196eb9, type: 3}
 --- !u!1001 &279114923
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -790,7 +858,17 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6179053010454761198, guid: 3db8ea15b2a9d2e4eab0ce61d6f986e1,
         type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6179053010454761198, guid: 3db8ea15b2a9d2e4eab0ce61d6f986e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6179053010454761198, guid: 3db8ea15b2a9d2e4eab0ce61d6f986e1,
+        type: 3}
+      propertyPath: m_AnchorMin.x
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 6357489835407824763, guid: 3db8ea15b2a9d2e4eab0ce61d6f986e1,
@@ -845,6 +923,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6536997525075492302, guid: 3db8ea15b2a9d2e4eab0ce61d6f986e1,
         type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6536997525075492302, guid: 3db8ea15b2a9d2e4eab0ce61d6f986e1,
+        type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
       objectReference: {fileID: 0}
@@ -874,3 +957,4 @@ SceneRoots:
   - {fileID: 279114923}
   - {fileID: 63970947}
   - {fileID: 9110649391932718082}
+  - {fileID: 267538456}

--- a/Assets/Scripts/UI/SettingUIManager.cs
+++ b/Assets/Scripts/UI/SettingUIManager.cs
@@ -7,9 +7,9 @@ namespace UI
     public class SettingUIManager : Singleton<SettingUIManager>
     {
         [Header("UI Canvas")] 
-        [Tooltip("¼³Á¤ UI Äµ¹ö½º")][SerializeField]private GameObject settingUICanvas;
+        [Tooltip("ï¿½ï¿½ï¿½ï¿½ UI Äµï¿½ï¿½ï¿½ï¿½")][SerializeField]private GameObject settingUICanvas;
         public GameObject SettingUICanvas => settingUICanvas;
-        [Tooltip("¼³Á¤ È°¼ºÈ­ ¹öÆ°")] public KeyCode settingKeyCode = KeyCode.Escape;
+        [Tooltip("ï¿½ï¿½ï¿½ï¿½ È°ï¿½ï¿½È­ ï¿½ï¿½Æ°")] public KeyCode settingKeyCode = KeyCode.Escape;
 
         [Header("BGM")] [SerializeField] private Slider bgmSlider;
         [Header("SFX")] [SerializeField] private Slider sfxSlider;
@@ -21,7 +21,7 @@ namespace UI
         // Start is called before the first frame update
         void Start()
         {
-            Initialize();
+            Invoke(nameof(Initialize), 0.1f);
         }
 
         // Update is called once per frame
@@ -74,7 +74,7 @@ namespace UI
 #if UNITY_EDITOR
             UnityEditor.EditorApplication.isPlaying = false;
 #else
-        Application.Quit(); // ¾îÇÃ¸®ÄÉÀÌ¼Ç Á¾·á
+        Application.Quit(); // ï¿½ï¿½ï¿½Ã¸ï¿½ï¿½ï¿½ï¿½Ì¼ï¿½ ï¿½ï¿½ï¿½ï¿½
 #endif
         }
 


### PR DESCRIPTION
## 🖥️Part
Programmer

## 📝작업 내용

> 마우스 커서 관리를 UIManager에서 관리합니다.

> 민감도 조절을 플레이어가 받을 수 있게 수정했습니다.
- 사용 방법
1. OnSensitivityValueChanged에 플레이어를 등록합니다.
2. 민감도를 조절하는 방법은 아래 스크린샷과 같이 진행합니다.
3. GetSensitivity를 통해 현재 민감도를 받아옵니다.
4. 그리고 플레이어의 민감도를 설정합니다. 

### 스크린샷 (선택)
<img width="159" alt="image" src="https://github.com/user-attachments/assets/c129937a-4774-4a7c-a92c-7463fe1609b8">

<img width="317" alt="image" src="https://github.com/user-attachments/assets/4fe1f774-700e-4798-9cd2-ba3366852874">

