### PR TITLE
Fix: Incorrect scene loading after death

### DIFF
--- a/Assets/Scripts/Anomaly/AnomalyObject/DuckMonsterProblem.cs
+++ b/Assets/Scripts/Anomaly/AnomalyObject/DuckMonsterProblem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Scenes;
 using Cinemachine;
 using DG.Tweening;
 using PlayerControl;
@@ -145,7 +146,8 @@ namespace Anomaly.Object
 
             // 암전 이후 게임 재시작
             yield return new WaitForSeconds(1f);
-            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            //SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            SceneController.Instance.ResetScene(0);
         }
     }
 }

--- a/Assets/Scripts/Anomaly/AnomalyObject/GhostOnBookcase.cs
+++ b/Assets/Scripts/Anomaly/AnomalyObject/GhostOnBookcase.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Scenes;
 using Cinemachine;
 using DG.Tweening;
 using PlayerControl;
@@ -114,7 +115,8 @@ namespace Anomaly.Object
 
             // 암전 이후 게임 재시작
             yield return new WaitForSeconds(1f);
-            SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            //SceneManager.LoadScene(SceneManager.GetActiveScene().buildIndex);
+            SceneController.Instance.ResetScene(0);
         }
     }
 }

--- a/Assets/Scripts/Anomaly/AnomalyObject/WaterBlockCollision.cs
+++ b/Assets/Scripts/Anomaly/AnomalyObject/WaterBlockCollision.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
+using System.Scenes;
 using Cinemachine.PostFX;
 using UnityEngine;
 using UnityEngine.Rendering;
@@ -86,7 +87,9 @@ namespace Anomaly.Object
                     vignette.intensity.value = 0.2f;
                     vignette.color.value = Color.black;
                     yield return new WaitForSeconds(1.1f);
-                    SceneManager.LoadScene(SceneManager.loadedSceneCount);
+                    
+                    //SceneManager.LoadScene(SceneManager.loadedSceneCount);
+                    SceneController.Instance.ResetScene(0);
                 }
 
                 yield return null;


### PR DESCRIPTION
## 🖥️Part
Design/Programmer

## 📝작업 내용

- 기존 이상현상 스크립트를 일부 수정하여 Player가 죽을 시 Scene이 원활하게 Reset 되도록 개선하였습니다
  - SceneController의 ResetScene 함수를 사용하였습니다
- 수정한 스크립트는 다음과 같습니다
  - DuckMosterProblem.cs
  - GhostOnBookcase.cs
  - WaterBlockCollsion.cs


