### PR TITLE
Dev/fix/audio stop next floor

### DIFF
--- a/Assets/Prefabs/Anomalys/Ch1/ToyTrack.prefab
+++ b/Assets/Prefabs/Anomalys/Ch1/ToyTrack.prefab
@@ -400,6 +400,74 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &7307411207322146024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8461852011314460364}
+  - component: {fileID: 6956332524142006590}
+  - component: {fileID: 1249793608419444891}
+  m_Layer: 0
+  m_Name: SoundEraseTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8461852011314460364
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7307411207322146024}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 167.94, z: -298.75}
+  m_LocalScale: {x: 20, y: 20, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8158470675507922593}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &6956332524142006590
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7307411207322146024}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &1249793608419444891
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7307411207322146024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 216ad388bd539a44891eb81c61cacfb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sfxPlayers:
+  - {fileID: 7025608390919361940}
 --- !u!1001 &659257018357981933
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -853,6 +921,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 1861582623314966908}
+    - targetCorrespondingSourceObject: {fileID: 662955977594263833, guid: 99f8fe26392c4a64ba4ff2c08db496ae,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 8461852011314460364}
     m_AddedComponents:
     - targetCorrespondingSourceObject: {fileID: 2526749721642443268, guid: 99f8fe26392c4a64ba4ff2c08db496ae,
         type: 3}

--- a/Assets/Prefabs/Anomalys/Ch3/Arny_Trumpet.prefab
+++ b/Assets/Prefabs/Anomalys/Ch3/Arny_Trumpet.prefab
@@ -1,5 +1,73 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2126849747286632839
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6918706517016203930}
+  - component: {fileID: 2766336047660204192}
+  - component: {fileID: 5446844786969732371}
+  m_Layer: 0
+  m_Name: SoundEraseTrigger
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6918706517016203930
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2126849747286632839}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 175.3, z: -284.42}
+  m_LocalScale: {x: 0.19522482, y: 0.773628, z: 0.11315558}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8569870630203827501}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2766336047660204192
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2126849747286632839}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 100, y: 40, z: 40}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &5446844786969732371
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2126849747286632839}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 216ad388bd539a44891eb81c61cacfb1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  sfxPlayers:
+  - {fileID: 111295072602094104}
 --- !u!1 &3160682561003081951
 GameObject:
   m_ObjectHideFlags: 0
@@ -240,6 +308,10 @@ PrefabInstance:
         type: 3}
       insertIndex: -1
       addedObject: {fileID: 7820290129787625686}
+    - targetCorrespondingSourceObject: {fileID: 662955977594263833, guid: 13cf5d27cd2bb47859a7b3b39c10635a,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 6918706517016203930}
     - targetCorrespondingSourceObject: {fileID: 662955977594263833, guid: 13cf5d27cd2bb47859a7b3b39c10635a,
         type: 3}
       insertIndex: -1


### PR DESCRIPTION
## 🖥️Part
Programmer

## 📝작업 내용
- ToyTrack.prefab을 수정하여 오리 사운드가 다음층으로 넘어갈 시 들리지않도록 하였습니다.
  - 다음층으로 넘어가는 문 앞에 Trigger를 간단하게 배치하여 통과 시 DuckSfxPlayer 가 stop 하도록 하였습니다.
- Arny_Trumpet.prefab 을 수정하여 다음 층으로 넘어갈 시 트럼펫 소리가 들리지 않도록 하였습니다
  - 다음층으로 넘어가는 문 앞에 Trigger를 간단하게 배치하여 통과 시 SfxPlayer 가 stop 하도록 하였습니다.


