### PR TITLE
Fix: door not opend error

### DIFF
--- a/Assets/Data/CH4_Anomaly/TV_Ghost.asset
+++ b/Assets/Data/CH4_Anomaly/TV_Ghost.asset
@@ -14,5 +14,5 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   type: 16
   anomalyName: TV_Ghost
-  problemPrefab: {fileID: 1789100236513454464, guid: c30d124d1522c8d41be0bb9e64d2d77f,
+  problemPrefab: {fileID: 1789100236513454464, guid: c7aeeb1ec2d279b4394a5a29a16e1a3d,
     type: 3}


### PR DESCRIPTION
## 🖥️Part
Programmer

## 📝작업 내용

4CH에서 가끔씩 다음 챕터의 문이 열리지 않는 버그 수정
- TV Ghost Anomaly 파일의 Prefab이 Missing으로 되어있어 Prefab을 다시 추가.

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/8a3a90df-9dad-4ab4-a5ca-05cd3bc0b648)
