### PR TITLE
Fix: reposition photo frame in PhotoFrameChange anomaly

### DIFF
--- a/Assets/Prefabs/Anomalys/Ch1/PhotoFrameChange_PlayerDelete.prefab
+++ b/Assets/Prefabs/Anomalys/Ch1/PhotoFrameChange_PlayerDelete.prefab
@@ -21,7 +21,7 @@ PrefabInstance:
     - target: {fileID: 1533009549088786084, guid: 10b63d49fff32eb4ca59bae81b08449c,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -190.6
+      value: -199.9
       objectReference: {fileID: 0}
     - target: {fileID: 1533009549088786084, guid: 10b63d49fff32eb4ca59bae81b08449c,
         type: 3}


### PR DESCRIPTION
## 🖥️Part
Programmer

## 📝작업 내용

- 1챕터의 PhotoFrameChange_PlayerDelete 이상현상에서 photoframe이 공중에 떠 있는 버그를 수정하였습니다
  - 이상현상 내부의 photoFrame 위치를 벽에 붙도록 조정하였습니다.

