### PR TITLE
Fix: Destroyed AudioPlayer reference error & SFX text update failure

### DIFF
--- a/Assets/Scripts/Utility/Audio/SoundPool.cs
+++ b/Assets/Scripts/Utility/Audio/SoundPool.cs
@@ -27,6 +27,8 @@ public class SoundPool
 
     public void ChangeMasterVolume(float masterVolume)
     {
+        audioPlayerList.RemoveAll(audioPlayer => audioPlayer == null || audioPlayer.AudioSource == null);
+        
         for (var i = 0; i < audioPlayerList.Count; ++i)
         {
             audioPlayerList[i].ChangeMasterVolume(masterVolume);


### PR DESCRIPTION
## 🖥️Part
Programmer

## 📝작업 내용
- 빌드버전에서 설정창 UI의 SFX 슬라이더 값을 변경 시 SFX 볼륨 텍스트가 갑자기 변하지 않는 현상을 해결하였습니다.
  - 파괴된 AudioSource를 접근하려는 MissingReferenceException을 해결하였습니다.
    - SoundPool.cs의 ChangeMasterVolume( )에서 audioPlayerList안의 audioPlayer가 유효한지 먼저 체크하도록 스크립트를 수정하였습니다.


