### PR TITLE
Fix: Resolve object overlapping issue in CH4

### DIFF
--- a/Assets/Prefabs/Map/DefaultMaps/DefaultMap_4Ch.prefab
+++ b/Assets/Prefabs/Map/DefaultMaps/DefaultMap_4Ch.prefab
@@ -7203,7 +7203,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4244459958986254, guid: 18960fbb660d3cb4cb789788db20d820, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -176.5
+      value: -174.44
       objectReference: {fileID: 0}
     - target: {fileID: 4244459958986254, guid: 18960fbb660d3cb4cb789788db20d820, type: 3}
       propertyPath: m_LocalRotation.w


### PR DESCRIPTION
## 🖥️Part
Programmer

## 📝작업 내용
- 챕터 4의 DefaultMap_4Ch 에서 서랍장과 ToyHouse 오브젝트가 겹쳐있는 현상을 해결하였습니다
  - 겹치지 않도록 ToyHouse 오브젝트의 위치를 변경하였습니다.

### 스크린샷 
바뀌기 전 (겹쳐있음)
![스크린샷(2388)](https://github.com/user-attachments/assets/7ae0ef49-9b94-4c7d-a6cf-e6725b29ec16)
바뀐 후 (서랍장과 띄어져있음)
![스크린샷(2389)](https://github.com/user-attachments/assets/1414c265-0fb0-4066-bdcd-9f4d18df6d31)

## 💬주의사항
DefualtMap_4Ch 를 수정하였으므로 Pull 시 주의바랍니다.

